### PR TITLE
Fix text loading by skipping uploaded .txt files for resizing

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,14 +89,13 @@ def create_dataset(destination_folder, size, *inputs):
         # copy the images to the datasets folder
         new_image_path = shutil.copy(image, destination_folder)
         
-        # resize the images if it's not a caption text file
-        ext = os.path.splitext(new_image_path)[-1].lower()
-        if ext != '.txt':
-            resize_image(new_image_path, new_image_path, size)
+        # if it's a caption text file skip the next bit
+        ext = os.path.splitext(new_image_path)[-1].lower()   
         if ext == '.txt':
-            shutil.copy(image, destination_folder)
             continue
-
+            
+        resize_image(new_image_path, new_image_path, size)
+        
         # copy the captions
         original_caption = inputs[index + 1]
 


### PR DESCRIPTION
This fixed text file captioning by allowing text files to be uploaded, but they are skipped when resizing as they aren't an image.