### PR TITLE
Autodownload models + Custom model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,42 +109,9 @@ pip install -r requirements.txt
 Finally, install pytorch Nightly:
 
 ```
-pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu121
+pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
 ```
 
-Now let's download the model checkpoints.
-
-First, download the following models under the `models/clip` foder:
-
-- https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true
-- https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true
-
-Second, download the following model under the `models/vae` folder:
-
-- https://huggingface.co/cocktailpeanut/xulf-dev/resolve/main/ae.sft?download=true
-
-Finally, download the following model under the `models/unet` folder:
-
-- https://huggingface.co/cocktailpeanut/xulf-dev/resolve/main/flux1-dev.sft?download=true
-
-The result file structure will be something like:
-
-```
-/models
-  /clip
-    clip_l.safetensors
-    t5xxl_fp16.safetensors
-  /unet
-    flux1-dev.sft
-  /vae
-    ae.sft
-/sd-scripts
-/outputs
-/env
-app.py
-requirements.txt
-...
-```
 
 # Start
 

--- a/app.py
+++ b/app.py
@@ -328,7 +328,7 @@ def download(base_model):
     model_path = os.path.join(model_folder, model_file)
     os.makedirs(model_folder, exist_ok=True)
     if not os.path.exists(model_path):
-        gr.Info(f"Downloading base model: {base_model}. Please wait. (You can check the terminal for the download progress)")
+        gr.Info(f"Downloading base model: {base_model}. Please wait. (You can check the terminal for the download progress)", duration=None)
         print(f"download {base_model}")
         hf_hub_download(repo_id=repo, local_dir=model_folder, filename=model_file)
 

--- a/app.py
+++ b/app.py
@@ -330,7 +330,7 @@ def download(base_model):
         os.makedirs(unet_folder, exist_ok=True)
         gr.Info(f"Downloading base model: {base_model}. Please wait. (You can check the terminal for the download progress)", duration=None)
         print(f"download {base_model}")
-        hf_hub_download(repo_id=repo, local_dir=model_folder, filename=model_file)
+        hf_hub_download(repo_id=repo, local_dir=unet_folder, filename=model_file)
 
     # download vae
     vae_folder = "models/vae"

--- a/app.py
+++ b/app.py
@@ -799,6 +799,7 @@ nav img.rotate { animation: rotate 2s linear infinite; }
 .hidden { display: none !important; }
 .codemirror-wrapper .cm-line { font-size: 12px !important; }
 label { font-weight: bold !important; }
+#start_training.clicked { background: silver; color: black; }
 """
 
 js = """
@@ -840,6 +841,11 @@ function() {
     }
     const debouncedClick = debounce(handleClick, 1000);
     document.addEventListener("input", debouncedClick);
+
+    document.querySelector("#start_training").addEventListener("click", (e) => {
+      e.target.classList.add("clicked")
+      e.target.innerHTML = "Training..."
+    })
 
 }
 """
@@ -933,7 +939,7 @@ with gr.Blocks(elem_id="app", theme=theme, css=css, fill_width=True) as demo:
         <p style="margin-top:0">Press start to start training.</p>
         """, elem_classes="group_padding")
                     refresh = gr.Button("Refresh", elem_id="refresh", visible=False)
-                    start = gr.Button("Start training", visible=False)
+                    start = gr.Button("Start training", visible=False, elem_id="start_training")
                     output_components.append(start)
                     train_script = gr.Textbox(label="Train script", max_lines=100, interactive=True)
                     train_config = gr.Textbox(label="Train config", max_lines=100, interactive=True)

--- a/app.py
+++ b/app.py
@@ -326,25 +326,25 @@ def download(base_model):
     else:
         unet_folder = f"models/unet/{repo}"
     unet_path = os.path.join(unet_folder, model_file)
-    os.makedirs(unet_folder, exist_ok=True)
     if not os.path.exists(unet_path):
+        os.makedirs(unet_folder, exist_ok=True)
         gr.Info(f"Downloading base model: {base_model}. Please wait. (You can check the terminal for the download progress)", duration=None)
         print(f"download {base_model}")
         hf_hub_download(repo_id=repo, local_dir=model_folder, filename=model_file)
 
     # download vae
     vae_folder = "models/vae"
-    os.makedirs(vae_folder, exist_ok=True)
     vae_path = os.path.join(vae_folder, "ae.sft")
     if not os.path.exists(vae_path):
+        os.makedirs(vae_folder, exist_ok=True)
         print(f"downloading ae.sft")
         hf_hub_download(repo_id="cocktailpeanut/xulf-dev", local_dir=vae_folder, filename="ae.sft")
 
     # download clip
     clip_folder = "models/clip"
-    os.makedirs(clip_folder, exist_ok=True)
     clip_l_path = os.path.join(clip_folder, "clip_l.safetensors")
     if not os.path.exists(clip_l_path):
+        os.makedirs(clip_folder, exist_ok=True)
         print(f"download clip_l.safetensors")
         hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename=clip_l_path)
 
@@ -564,11 +564,14 @@ def start_training(
     sample_prompts,
 ):
     # write custom script and toml
-    os.makedirs("models", exist_ok=True)
-    os.makedirs("outputs", exist_ok=True)
+    if not os.path.exists("models"):
+        os.makedirs("models", exist_ok=True)
+    if not os.path.exists("outputs"):
+        os.makedirs("outputs", exist_ok=True)
     output_name = slugify(lora_name)
     output_dir = resolve_path_without_quotes(f"outputs/{output_name}")
-    os.makedirs(output_dir, exist_ok=True)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir, exist_ok=True)
 
     download(base_model)
 

--- a/app.py
+++ b/app.py
@@ -346,13 +346,13 @@ def download(base_model):
     if not os.path.exists(clip_l_path):
         os.makedirs(clip_folder, exist_ok=True)
         print(f"download clip_l.safetensors")
-        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename=clip_l_path)
+        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="clip_l.safetensors")
 
     # download t5xxl
     t5xxl_path = os.path.join(clip_folder, "t5xxl_fp16.safetensors")
     if not os.path.exists(t5xxl_path):
         print(f"download t5xxl_fp16.safetensors")
-        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename=t5xxl_path)
+        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="t5xxl_fp16.safetensors")
 
 
 def resolve_path(p):

--- a/app.py
+++ b/app.py
@@ -320,17 +320,40 @@ def download(base_model):
     model_file = model["file"]
     repo = model["repo"]
 
+    # download unet
     if base_model == "flux-dev" or base_model == "flux-schnell":
-        model_folder = "models/unet"
+        unet_folder = "models/unet"
     else:
-        model_folder = f"models/unet/{repo}"
-    # download if it doesn't exist
-    model_path = os.path.join(model_folder, model_file)
-    os.makedirs(model_folder, exist_ok=True)
-    if not os.path.exists(model_path):
+        unet_folder = f"models/unet/{repo}"
+    unet_path = os.path.join(unet_folder, model_file)
+    os.makedirs(unet_folder, exist_ok=True)
+    if not os.path.exists(unet_path):
         gr.Info(f"Downloading base model: {base_model}. Please wait. (You can check the terminal for the download progress)", duration=None)
         print(f"download {base_model}")
         hf_hub_download(repo_id=repo, local_dir=model_folder, filename=model_file)
+
+    # download vae
+    vae_folder = "models/vae"
+    os.makedirs(vae_folder, exist_ok=True)
+    vae_path = os.path.join(vae_folder, "ae.sft")
+    if not os.path.exists(vae_path):
+        print(f"downloading ae.sft")
+        hf_hub_download(repo_id="cocktailpeanut/xulf-dev", local_dir=vae_folder, filename="ae.sft")
+
+    # download clip
+    clip_folder = "models/clip"
+    os.makedirs(clip_folder, exist_ok=True)
+    clip_l_path = os.path.join(clip_folder, "clip_l.safetensors")
+    if not os.path.exists(clip_l_path):
+        print(f"download clip_l.safetensors")
+        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename=clip_l_path)
+
+    # download t5xxl
+    t5xxl_path = os.path.join(clip_folder, "t5xxl_fp16.safetensors")
+    if not os.path.exists(t5xxl_path):
+        print(f"download t5xxl_fp16.safetensors")
+        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename=t5xxl_path)
+
 
 def resolve_path(p):
     current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/app.py
+++ b/app.py
@@ -337,7 +337,8 @@ def download(base_model):
     vae_path = os.path.join(vae_folder, "ae.sft")
     if not os.path.exists(vae_path):
         os.makedirs(vae_folder, exist_ok=True)
-        print(f"downloading ae.sft")
+        gr.Info(f"Downloading vae")
+        print(f"downloading ae.sft...")
         hf_hub_download(repo_id="cocktailpeanut/xulf-dev", local_dir=vae_folder, filename="ae.sft")
 
     # download clip
@@ -345,6 +346,7 @@ def download(base_model):
     clip_l_path = os.path.join(clip_folder, "clip_l.safetensors")
     if not os.path.exists(clip_l_path):
         os.makedirs(clip_folder, exist_ok=True)
+        gr.Info(f"Downloading clip...")
         print(f"download clip_l.safetensors")
         hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="clip_l.safetensors")
 
@@ -352,6 +354,7 @@ def download(base_model):
     t5xxl_path = os.path.join(clip_folder, "t5xxl_fp16.safetensors")
     if not os.path.exists(t5xxl_path):
         print(f"download t5xxl_fp16.safetensors")
+        gr.Info(f"Downloading t5xxl...")
         hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="t5xxl_fp16.safetensors")
 
 

--- a/install.js
+++ b/install.js
@@ -58,25 +58,25 @@ module.exports = {
         ]
       }
     },
-    {
-      method: "fs.download",
-      params: {
-        uri: [
-          "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
-          "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
-        ],
-        dir: "models/clip"
-      }
-    },
-    {
-      method: "fs.download",
-      params: {
-        uri: [
-          "https://huggingface.co/cocktailpeanut/xulf-dev/resolve/main/ae.sft?download=true",
-        ],
-        dir: "models/vae"
-      }
-    },
+//    {
+//      method: "fs.download",
+//      params: {
+//        uri: [
+//          "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/clip_l.safetensors?download=true",
+//          "https://huggingface.co/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp16.safetensors?download=true",
+//        ],
+//        dir: "models/clip"
+//      }
+//    },
+//    {
+//      method: "fs.download",
+//      params: {
+//        uri: [
+//          "https://huggingface.co/cocktailpeanut/xulf-dev/resolve/main/ae.sft?download=true",
+//        ],
+//        dir: "models/vae"
+//      }
+//    },
 //    {
 //      method: "fs.download",
 //      params: {

--- a/install.js
+++ b/install.js
@@ -77,15 +77,15 @@ module.exports = {
         dir: "models/vae"
       }
     },
-    {
-      method: "fs.download",
-      params: {
-        uri: [
-          "https://huggingface.co/cocktailpeanut/xulf-dev/resolve/main/flux1-dev.sft?download=true",
-        ],
-        dir: "models/unet"
-      }
-    },
+//    {
+//      method: "fs.download",
+//      params: {
+//        uri: [
+//          "https://huggingface.co/cocktailpeanut/xulf-dev/resolve/main/flux1-dev.sft?download=true",
+//        ],
+//        dir: "models/unet"
+//      }
+//    },
     {
       method: "fs.link",
       params: {

--- a/models.yaml
+++ b/models.yaml
@@ -1,0 +1,19 @@
+flux-dev:
+    repo: cocktailpeanut/xulf-dev
+    base: black-forest-labs/FLUX.1-dev
+    license: other
+    license_name: flux-1-dev-non-commercial-license
+    license_link: https://huggingface.co/black-forest-labs/FLUX.1-dev/blob/main/LICENSE.md
+    file: flux1-dev.sft
+flux-schnell:
+    repo: black-forest-labs/FLUX.1-schnell
+    base: black-forest-labs/FLUX.1-schnell
+    license: apache-2.0
+    file: flux1-schnell.safetensors
+bdsqlsz/flux1-dev2pro-single:
+    repo: bdsqlsz/flux1-dev2pro-single
+    base: black-forest-labs/FLUX.1-dev
+    license: other
+    license_name: flux-1-dev-non-commercial-license
+    license_link: https://huggingface.co/black-forest-labs/FLUX.1-dev/blob/main/LICENSE.md
+    file: flux1-dev2pro.safetensors


### PR DESCRIPTION
1. Instead of manually running scripts to install models, download the models directly from the app
2. Support base models other than flux-dev: schnell + dev2pro => anyone can add by updating the models.yaml file and sending a PR