### PR TITLE
feat: added arguments for more flexibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ from transformers import AutoProcessor, AutoModelForCausalLM
 from gradio_logsview import LogsView, LogsViewRunner
 from huggingface_hub import hf_hub_download, HfApi
 from library import flux_train_utils, huggingface_util
-from argparse import Namespace
+import argparse
 import train_network
 import toml
 import re
@@ -158,7 +158,7 @@ def upload_hf(base_model, lora_rows, repo_owner, repo_name, repo_visibility, hf_
     src = lora_rows
     repo_id = f"{repo_owner}/{repo_name}"
     gr.Info(f"Uploading to Huggingface. Please Stand by...", duration=None)
-    args = Namespace(
+    args = argparse.Namespace(
         huggingface_repo_id=repo_id,
         huggingface_repo_type="model",
         huggingface_repo_visibility=repo_visibility,
@@ -1115,5 +1115,23 @@ with gr.Blocks(elem_id="app", theme=theme, css=css, fill_width=True) as demo:
     demo.load(fn=loaded, js=js, outputs=[hf_token, hf_login, hf_logout, repo_owner])
     refresh.click(update, inputs=listeners, outputs=[train_script, train_config, dataset_folder])
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--debug", type=bool, default=True)
+    parser.add_argument("--share", type=bool, default=False)
+    parser.add_argument("--show_error", type=bool, default=True)
+    parser.add_argument("--server_name", type=str, default="localhost")
+    parser.add_argument("--server_port", type=int, default=7860)
+
+    args = parser.parse_args()
+
     cwd = os.path.dirname(os.path.abspath(__file__))
-    demo.launch(debug=True, show_error=True, allowed_paths=[cwd])
+
+    demo.launch(
+        debug=args.debug,
+        show_error=args.show_error,
+        server_name=args.server_name,
+        server_port=args.server_port,
+        share=args.share,
+        allowed_paths=[cwd]
+    )


### PR DESCRIPTION
Use argparse to be able to pass server address and port, along with other hardcoded parameters.