### PR TITLE
Fix: Prevent crash when training with more than 75 images and captions

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,8 @@ from argparse import Namespace
 import train_network
 import toml
 import re
-MAX_IMAGES = 150
+# This can be increased if you have >300 images (or >150 images with captions).
+MAX_IMAGES = 300
 
 with open('models.yaml', 'r') as file:
     models = yaml.safe_load(file)


### PR DESCRIPTION
Closes #341.

This PR fixes an `IndexError` that occurs when the total number of input files (images + captions) exceeds the hardcoded limit for UI components.

### Problem:

The application creates a fixed number of UI caption fields based on `MAX_IMAGES = 150`. However, the training process iterates over all input files, including both images and their `.txt` captions. If the total file count exceeds 150 (e.g., 76 images + 76 captions), the application crashes with an "index out of range" error when trying to access a UI element that doesn't exist.

The existing validation only checked the image count, which did not prevent the crash.

### Solution:

- Increase `MAX_IMAGES` from 150 to 300. This raises the effective limit to approximately 150 images with their corresponding captions.
- Clarify the code comment to reflect that this limit applies to the total number of files.

A more permanent solution would be to dynamically generate UI components, but this change resolves the immediate crashing issue for larger datasets.