### PR TITLE
train_batch_size fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -515,7 +515,8 @@ def gen_toml(
   dataset_folder,
   resolution,
   class_tokens,
-  num_repeats
+  num_repeats,
+  train_batch_size=1  # Add default value for backward compatibility
 ):
     toml = f"""[general]
 shuffle_caption = false
@@ -524,7 +525,7 @@ keep_tokens = 1
 
 [[datasets]]
 resolution = {resolution}
-batch_size = 1
+batch_size = {train_batch_size}
 keep_tokens = 1
 
   [[datasets.subsets]]
@@ -658,6 +659,10 @@ def update(
     sample_every_n_steps,
     *advanced_components,
 ):
+    # Map advanced_component_ids to their values
+    advanced_args = dict(zip(advanced_component_ids, advanced_components))
+    # Default to 1 if not set
+    train_batch_size = advanced_args.get('--train_batch_size', 1)
     output_name = slugify(lora_name)
     dataset_folder = str(f"datasets/{output_name}")
     sh = gen_sh(
@@ -681,7 +686,8 @@ def update(
         dataset_folder,
         resolution,
         class_tokens,
-        num_repeats
+        num_repeats,
+        train_batch_size  # Pass the batch size here
     )
     return gr.update(value=sh), gr.update(value=toml), dataset_folder
 


### PR DESCRIPTION
fix train_batch_size so that it properly passes the value the user typed into the field instead of hard coding 1. If no value is specified, it should still use the value of 1.

This matters because people with extra Vram will be able to utilize it during training by increasing this value.