### PR TITLE
Port upstream changes: MAX_IMAGES=300 (#418), support --train_batch_s…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `app.py`: Gradio UI and orchestration (dataset prep, training flags, sampling, HF upload).
+- `models/`: Downloaded base model files (`unet`, `vae`, `clip`). Auto‑populated by the app.
+- `outputs/`: Training artifacts per LoRA slug (e.g., `outputs/<lora-name>/...`).
+- `models.yaml`: Base models list (repo, file, license metadata) used by downloads/publishing.
+- `requirements.txt`: Python deps for the UI/orchestration; `sd-scripts/` (kohya) has its own.
+- `Dockerfile`, `docker-compose.yml`: Containerized run with GPU.
+- Assets: screenshots and icons used by README/UI.
+
+## Build, Test, and Development Commands
+- Create venv (Linux/macOS): `python -m venv env && source env/bin/activate`
+- Create venv (Windows): `python -m venv env && env\\Scripts\\activate`
+- Install deps:
+  - `git clone -b sd3 https://github.com/kohya-ss/sd-scripts`
+  - `cd sd-scripts && pip install -r requirements.txt && cd ..`
+  - `pip install -r requirements.txt`
+  - Torch (CUDA 12.1): `pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121`
+- Run locally: `python app.py` then open `http://localhost:7860`.
+- Docker: `docker compose up -d --build`.
+
+## Coding Style & Naming Conventions
+- Python: PEP 8, 4‑space indentation, function/variable `snake_case`, modules/files lowercase with underscores.
+- Keep UI labels aligned with underlying `sd-scripts` flags (e.g., `--network_dim`).
+- Prefer small, focused functions; avoid side effects in helpers.
+
+## Testing Guidelines
+- No formal test suite. Use manual smoke tests:
+  - Launch app; verify tabs render and logs stream.
+  - Train with a small image set; confirm `outputs/<slug>/` contains `dataset.toml`, logs, and sample images (if enabled).
+  - Hugging Face publish: login with token, upload a sample LoRA.
+
+## Commit & Pull Request Guidelines
+- Commits: concise, imperative subject (e.g., “add docker compose healthcheck”).
+- PRs: clear description, steps to reproduce/verify, screenshots for UI changes, and note if `models.yaml`/docs were updated. Keep scope small.
+
+## Security & Configuration Tips
+- Do not commit tokens (`HF_TOKEN`), model weights, or large `outputs/` artifacts.
+- Respect model licenses in `models.yaml` when adding new bases.
+- GPU differences matter; document VRAM assumptions in PRs that tune defaults.

--- a/app.py
+++ b/app.py
@@ -21,7 +21,8 @@ from argparse import Namespace
 import train_network
 import toml
 import re
-MAX_IMAGES = 150
+# This can be increased if you have >300 images (or >150 images with captions).
+MAX_IMAGES = 300
 
 with open('models.yaml', 'r') as file:
     models = yaml.safe_load(file)
@@ -515,7 +516,8 @@ def gen_toml(
   dataset_folder,
   resolution,
   class_tokens,
-  num_repeats
+  num_repeats,
+  train_batch_size: int = 1
 ):
     toml = f"""[general]
 shuffle_caption = false
@@ -524,7 +526,7 @@ keep_tokens = 1
 
 [[datasets]]
 resolution = {resolution}
-batch_size = 1
+batch_size = {train_batch_size}
 keep_tokens = 1
 
   [[datasets.subsets]]
@@ -533,14 +535,34 @@ keep_tokens = 1
   num_repeats = {num_repeats}"""
     return toml
 
-def update_total_steps(max_train_epochs, num_repeats, images):
+def update_total_steps(max_train_epochs, num_repeats, files):
+    """
+    Re-compute the expected training steps.
+
+    • `files` is the list that comes from the <gr.File> uploader.  
+      It can contain both images and .txt caption files, so we
+      first discard anything that ends in '.txt'.
+
+    • We then multiply the surviving image-count by the repeats
+      and epochs to get the total step estimate.
+    """
     try:
-        num_images = len(images)
+        # keep everything that is *not* a .txt file
+        image_files = [
+            f for f in files
+            if isinstance(f, str)
+            and not f.lower().endswith(".txt")
+        ]
+        num_images = len(image_files)
         total_steps = max_train_epochs * num_images * num_repeats
-        print(f"max_train_epochs={max_train_epochs} num_images={num_images}, num_repeats={num_repeats}, total_steps={total_steps}")
-        return gr.update(value = total_steps)
-    except:
-        print("")
+        print(
+            f"max_train_epochs={max_train_epochs} "
+            f"num_images={num_images}, num_repeats={num_repeats}, "
+            f"total_steps={total_steps}"
+        )
+        return gr.update(value=total_steps)
+    except Exception as e:
+        print("update_total_steps error:", e)
 
 def set_repo(lora_rows):
     selected_name = os.path.basename(lora_rows)
@@ -658,6 +680,17 @@ def update(
     sample_every_n_steps,
     *advanced_components,
 ):
+    # Extract optional train batch size from advanced flags if present
+    try:
+        advanced_args = dict(zip(advanced_component_ids, advanced_components))
+        tbs_raw = advanced_args.get('--train_batch_size', 1)
+        # Handle empty strings and non-int values gracefully
+        if tbs_raw in (None, ""):
+            train_batch_size = 1
+        else:
+            train_batch_size = int(tbs_raw)
+    except Exception:
+        train_batch_size = 1
     output_name = slugify(lora_name)
     dataset_folder = str(f"datasets/{output_name}")
     sh = gen_sh(
@@ -681,7 +714,8 @@ def update(
         dataset_folder,
         resolution,
         class_tokens,
-        num_repeats
+        num_repeats,
+        train_batch_size
     )
     return gr.update(value=sh), gr.update(value=toml), dataset_folder
 


### PR DESCRIPTION
- Summary:
    - Increase MAX_IMAGES to 300 to avoid large-dataset crashes (ports upstream #418).
    - Add support for --train_batch_size flowing into dataset.toml (ports upstream #435).
    - Keep sample args formatting unchanged.
    - Add AGENTS.md contributor guide.
- Test Plan:
    - Launch app; upload >150 images (+ matching captions) to confirm no crash.
    - Set --train_batch_size to 2 in Advanced; click Refresh; start a short run; confirm outputs//dataset.toml shows batch_size = 2.
    - Sanity: python -m py_compile app.py succeeds.
- Notes:
    - Default batch size remains 1 if the flag is unset/invalid.
    - No newline handling changes in generated scripts.