### PR TITLE
Fix Dockerfile and docker-compose settings for Fluxgym

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,60 @@
+# Dockerfile
+
 # Base image with CUDA 12.2
 FROM nvidia/cuda:12.2.2-base-ubuntu22.04
 
-# Install pip if not already installed
-RUN apt-get update -y && apt-get install -y \
-    python3-pip \
-    python3-dev \
-    git \
-    build-essential  # Install dependencies for building extensions
+ENV DEBIAN_FRONTEND=noninteractive
 
-# Define environment variables for UID and GID and local timezone
-ENV PUID=${PUID:-1000}
-ENV PGID=${PGID:-1000}
+# Install system dependencies and pip
+RUN apt-get update -y && \
+    apt-get install -y \
+        python3-pip \
+        python3-dev \
+        git \
+        build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
-# Create a group with the specified GID
-RUN groupadd -g "${PGID}" appuser
-# Create a user with the specified UID and GID
-RUN useradd -m -s /bin/sh -u "${PUID}" -g "${PGID}" appuser
+# Upgrade pip, setuptools, wheel so dependency resolution is more robust
+RUN python3 -m pip install --upgrade pip setuptools wheel && \
+    ln -s /usr/bin/python3 /usr/bin/python || true
+
+# Define environment variables for UID and GID
+ENV PUID=1000 \
+    PGID=1000
+
+# Create a non-root user
+RUN groupadd -g ${PGID} appuser && \
+    useradd -m -s /bin/sh -u ${PUID} -g ${PGID} appuser
 
 WORKDIR /app
 
-# Get sd-scripts from kohya-ss and install them
+# Get sd-scripts from kohya-ss and install their dependencies
 RUN git clone -b sd3 https://github.com/kohya-ss/sd-scripts && \
     cd sd-scripts && \
-    pip install --no-cache-dir -r ./requirements.txt
+    python3 -m pip install --no-cache-dir -r ./requirements.txt
 
-# Install main application dependencies
-COPY ./requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r ./requirements.txt
+# Install main FluxGym application dependencies
+COPY ./requirements.txt /app/requirements.txt
+RUN python3 -m pip install --no-cache-dir -r /app/requirements.txt
 
 # Install Torch, Torchvision, and Torchaudio for CUDA 12.2
-RUN pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu122/torch_stable.html
+RUN python3 -m pip install torch torchvision torchaudio \
+    --extra-index-url https://download.pytorch.org/whl/cu122/torch_stable.html
 
+# Clean up build-only artifacts
+RUN rm -rf /app/sd-scripts /app/requirements.txt
+
+# Ensure ownership for the non-root user
 RUN chown -R appuser:appuser /app
 
-# delete redundant requirements.txt and sd-scripts directory within the container
-RUN rm -r ./sd-scripts
-RUN rm ./requirements.txt
-
-#Run application as non-root
+# Run application as non-root
 USER appuser
 
-# Copy fluxgym application code
-COPY . ./fluxgym
+# Copy fluxgym application code (will be overridden by the bind mount at runtime)
+COPY . /app/fluxgym
 
 EXPOSE 7860
-
-ENV GRADIO_SERVER_NAME="0.0.0.0"
+ENV GRADIO_SERVER_NAME=0.0.0.0
 
 WORKDIR /app/fluxgym
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,13 @@ services:
       resources:
         reservations:
           devices:
-          - driver: nvidia
-            count: all
-            capabilities: [gpu]
+            - driver: nvidia
+              device_ids:
+                - "0"          # Use only GPU with index 1
+              capabilities: [gpu]
+          memory: 32g           # Optional: Reserve 32 GB RAM
+        limits:
+          memory: 32g           # Max RAM usage
+    memswap_limit: 40g          # Total allowed memory+swap (48g RAM + 12g swap)
     restart: unless-stopped
+    #shm_size: "8g"


### PR DESCRIPTION
This PR improves the Docker-based setup for Fluxgym:

- Update Dockerfile to use `python3 -m pip` and upgrade pip/setuptools/wheel to avoid `ResolutionTooDeep` errors when installing requirements.
- Ensure `sd-scripts` dependencies are installed in a clean, reproducible way in the image.
- Adjust docker-compose settings so training runs more reliably with GPU and memory limits (including larger RAM/swap reservations suitable for PyTorch training).

These changes make it easier for users to build and run Fluxgym in Docker without hitting dependency resolution errors or training crashes.
