### PR TITLE
fixed train.sh generation newline bug which broke sample generation i…

### DIFF
--- a/app.py
+++ b/app.py
@@ -406,8 +406,11 @@ def gen_sh(
     ############# Sample args ########################
     sample = ""
     if len(sample_prompts) > 0 and sample_every_n_steps > 0:
-        sample = f"""--sample_prompts={sample_prompts_path} --sample_every_n_steps="{sample_every_n_steps}" {line_break}"""
-
+        #sample = f"""--sample_prompts={sample_prompts_path} --sample_every_n_steps="{sample_every_n_steps}" {line_break}"""
+        sample = (
+            f"\n  --sample_prompts={sample_prompts_path} "
+            f'--sample_every_n_steps="{sample_every_n_steps}" {line_break}'
+        )
 
     ############# Optimizer args ########################
 #    if vram == "8G":


### PR DESCRIPTION
In linux, a newline bug in how "train.sh" is assembled rendered sample generation ineffective. 

Previously train.sh would end up like:

`--max_grad_norm 0.0 \--sample_prompts=`

instead of

```
--max_grad_norm 0.0 \
--sample_prompts=
```

which meant everything worked EXCEPT sample generation.