### PR TITLE
bluefairy / torch fix

### DIFF
--- a/torch.js
+++ b/torch.js
@@ -16,9 +16,10 @@ module.exports = {
       "when": "{{platform === 'win32' && gpu === 'amd'}}",
       "method": "shell.run",
       "params": {
+        "bluefairy": "off",
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch-directml torch torchvision torchaudio --force-reinstall --no-deps"
+        "message": "uv pip install torch-directml torch torchvision torchaudio numpy==1.26.4 --force-reinstall"
       }
     },
     // windows cpu
@@ -46,9 +47,10 @@ module.exports = {
       "when": "{{platform === 'linux' && gpu === 'nvidia'}}",
       "method": "shell.run",
       "params": {
+        "bluefairy": "off",
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 --force-reinstall"
+        "message": "uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121 --force-reinstall"
       }
     },
     // linux rocm (amd)
@@ -58,7 +60,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.4 --force-reinstall --no-deps"
+        "message": "uv pip install torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0 --index-url https://download.pytorch.org/whl/rocm7.1 --force-reinstall --no-deps"
       }
     },
     // linux cpu


### PR DESCRIPTION
- disable bluefairy protection for Linux NVIDIA and Windows AMD
- stable torch for Linux NVIDIA
- pinned torch for Linux AMD (because the rocm version changes across different torch versions)