### PR TITLE
Add FLUX.1 Krea training + RunPod serverless backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,9 @@ cudnn_windows/
 bitsandbytes_windows/
 bitsandbytes_windows_deprecated/
 dataset/
+datasets/
+models/
+outputs/
 __pycache__/
 venv/
 **/.hadolint.yml

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Copy to .env and fill in. .env is gitignored.
+# Leave RUNPOD_* blank to run training locally (default FluxGym behaviour).
+
+# --- RunPod ---
+# Your RunPod API key (https://www.runpod.io/console/user/settings).
+RUNPOD_API_KEY=
+# Set by `python runpod/deploy.py`. When this AND RUNPOD_API_KEY are set, the
+# local UI submits training to this serverless endpoint instead of running locally.
+RUNPOD_ENDPOINT_ID=
+# Set by deploy.py; reuse the same volume so base models download only once.
+RUNPOD_NETWORK_VOLUME_ID=
+
+# --- Docker image (built/pushed by runpod/build_and_push.sh) ---
+DOCKER_IMAGE=docker.io/<your-user>/fluxgym-runpod:latest
+
+# --- deploy.py knobs (sensible defaults; override as needed) ---
+RUNPOD_NAME=fluxgym-krea
+RUNPOD_DATA_CENTER_ID=US-OR-1
+RUNPOD_VOLUME_GB=100
+RUNPOD_CONTAINER_DISK_GB=30
+# GPU pool. AMPERE_48 = 48GB Ampere (A40/A6000), a good fit for FLUX LoRA.
+RUNPOD_GPU_IDS=AMPERE_48
+RUNPOD_WORKERS_MAX=1
+RUNPOD_IDLE_TIMEOUT=60
+
+# --- HuggingFace (where the trained LoRA is pushed) ---
+# If HF_REPO_OWNER + HF_TOKEN are set, the worker pushes the LoRA to
+# <owner>/<lora-name>. Otherwise it stays on the network volume.
+HF_TOKEN=
+HF_REPO_OWNER=
+HF_VISIBILITY=public

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Secrets / local config
+.env
+
+# Python
+__pycache__/
+*.pyc
+env/
+venv/
+
+# Runtime artifacts
+sd-scripts/
+HF_TOKEN

--- a/Dockerfile.runpod
+++ b/Dockerfile.runpod
@@ -1,0 +1,41 @@
+# RunPod serverless image for FluxGym remote training.
+# Unlike the stock Dockerfile, this KEEPS sd-scripts in the image (the worker
+# runs sd-scripts/flux_train_network.py at runtime and there is no bind-mount
+# on serverless) and launches the training handler instead of the Gradio UI.
+FROM nvidia/cuda:12.4.1-base-ubuntu22.04
+
+RUN apt-get update -y && apt-get install -y \
+    python3-pip \
+    python3-dev \
+    git \
+    build-essential
+
+WORKDIR /app
+
+# Clone Kohya sd-scripts (sd3 branch) and install its deps. KEEP the directory.
+RUN git clone -b sd3 https://github.com/kohya-ss/sd-scripts && \
+    cd sd-scripts && \
+    pip install --no-cache-dir -r ./requirements.txt
+
+# Install FluxGym app deps + the RunPod SDK.
+COPY ./requirements.txt ./requirements.txt
+COPY ./requirements-runpod.txt ./requirements-runpod.txt
+RUN pip install --no-cache-dir -r ./requirements.txt && \
+    pip install --no-cache-dir -r ./requirements-runpod.txt
+
+# Torch for CUDA 12.4.
+RUN pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+
+# Copy the FluxGym application code into the repo root, then move sd-scripts in
+# so it sits at /app/fluxgym/sd-scripts (where handler.py expects it).
+COPY . /app/fluxgym
+RUN cp -r /app/sd-scripts /app/fluxgym/sd-scripts
+
+WORKDIR /app/fluxgym
+
+ENV HF_HUB_ENABLE_HF_TRANSFER=1
+ENV PYTHONUNBUFFERED=1
+
+# entrypoint wires the network volume to ./models, then starts the worker.
+RUN chmod +x /app/fluxgym/runpod/entrypoint.sh
+ENTRYPOINT ["/app/fluxgym/runpod/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -35,13 +35,70 @@ FluxGym supports 100% of Kohya sd-scripts features through an [Advanced](#advanc
 1. Flux1-dev
 2. Flux1-dev2pro (as explained here: https://medium.com/@zhiwangshi28/why-flux-lora-so-hard-to-train-and-how-to-overcome-it-a0c70bc59eaf)
 3. Flux1-schnell (Couldn't get high quality results, so not really recommended, but feel free to experiment with it)
-4. More?
+4. Flux1-Krea-dev (select `flux-krea-dev` in the dropdown — see note below)
+5. More?
+
+### Training FLUX.1 Krea [dev]
+
+FLUX.1 Krea is architecturally a sibling of FLUX.1-dev (same VAE / CLIP-L / T5
+encoders, guidance-distilled), so it trains with the exact same recipe — the
+`flux-krea-dev` entry in [models.yaml](models.yaml) is all that's needed.
+
+Two things to know:
+
+- It uses the **full bf16 single-file checkpoint** (`InvokeAI/FLUX.1-Krea-dev`).
+  Do **not** point it at the ComfyUI `fp8_scaled` file — that trains to pure
+  noise ([kohya-ss/sd-scripts#2166](https://github.com/kohya-ss/sd-scripts/issues/2166)).
+  FluxGym already quantizes on the GPU via `--fp8_base`.
+- Because Krea is guidance-distilled, keep `--guidance_scale 1.0` (the default).
+  Higher values destroy the distilled guidance embedding during training.
+
+Optional alternative route: train the LoRA on `bdsqlsz/flux1-dev2pro-single`
+(a de-distilled base, cleaner gradient signal) and run the resulting LoRA on
+Krea at inference. LoRAs are portable across the FLUX.1-dev family. Quality of
+this transfer isn't guaranteed (Krea's weights have drifted aesthetically from
+dev), so A/B test it against training directly on `flux-krea-dev`.
 
 The models are automatically downloaded when you start training with the model selected.
 
 You can easily add more to the supported models list by editing the [models.yaml](models.yaml) file. If you want to share some interesting base models, please send a PR.
 
 ---
+
+# Remote training on RunPod (local UI → cloud GPU)
+
+You can run the FluxGym UI locally (e.g. on a Mac with no NVIDIA GPU) while the
+actual training runs on a RunPod serverless GPU. The dataset is sent with each
+job, base models are cached on a RunPod network volume, and the finished LoRA is
+pushed to your HuggingFace account.
+
+It's opt-in: if `RUNPOD_API_KEY` and `RUNPOD_ENDPOINT_ID` are absent from `.env`,
+FluxGym trains locally exactly as before.
+
+**Setup:**
+
+0. The `runpod` SDK is in `requirements.txt` — if you're upgrading an existing
+   install, re-run `pip install -r requirements.txt` so it's available locally.
+1. `cp .env.example .env` and fill in `RUNPOD_API_KEY`, `DOCKER_IMAGE`
+   (your registry path), and `HF_TOKEN` + `HF_REPO_OWNER`.
+2. Build & push the worker image:
+   ```
+   ./runpod/build_and_push.sh
+   ```
+3. Provision the volume + template + endpoint:
+   ```
+   python runpod/deploy.py
+   ```
+   Paste the printed `RUNPOD_ENDPOINT_ID` and `RUNPOD_NETWORK_VOLUME_ID` into `.env`.
+   In the RunPod dashboard, raise the endpoint's **Execution Timeout** to cover
+   your longest run.
+4. Start FluxGym locally (`python app.py`), configure your LoRA as usual, and
+   click **Start training** — logs stream back from the GPU into the terminal,
+   and the LoRA lands in `https://huggingface.co/<owner>/<lora-name>`.
+
+The first job downloads ~30GB of base models to the volume and is slow; later
+jobs reuse the cache. See [`runpod/`](runpod/) for the handler, deploy, and
+build scripts, and [Dockerfile.runpod](Dockerfile.runpod) for the worker image.
 
 # How people are using Fluxgym
 

--- a/app.py
+++ b/app.py
@@ -21,95 +21,22 @@ from argparse import Namespace
 import train_network
 import toml
 import re
+from dotenv import load_dotenv
+from fluxgym_core import (
+    models,
+    resolve_path,
+    resolve_path_without_quotes,
+    readme,
+    download,
+    resize_image,
+    create_dataset,
+)
+import runpod_client
+
+# Load .env so RunPod/HF settings are available (no-op if the file is absent).
+load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".env"))
+
 MAX_IMAGES = 150
-
-with open('models.yaml', 'r') as file:
-    models = yaml.safe_load(file)
-
-def readme(base_model, lora_name, instance_prompt, sample_prompts):
-
-    # model license
-    model_config = models[base_model]
-    model_file = model_config["file"]
-    base_model_name = model_config["base"]
-    license = None
-    license_name = None
-    license_link = None
-    license_items = []
-    if "license" in model_config:
-        license = model_config["license"]
-        license_items.append(f"license: {license}")
-    if "license_name" in model_config:
-        license_name = model_config["license_name"]
-        license_items.append(f"license_name: {license_name}")
-    if "license_link" in model_config:
-        license_link = model_config["license_link"]
-        license_items.append(f"license_link: {license_link}")
-    license_str = "\n".join(license_items)
-    print(f"license_items={license_items}")
-    print(f"license_str = {license_str}")
-
-    # tags
-    tags = [ "text-to-image", "flux", "lora", "diffusers", "template:sd-lora", "fluxgym" ]
-
-    # widgets
-    widgets = []
-    sample_image_paths = []
-    output_name = slugify(lora_name)
-    samples_dir = resolve_path_without_quotes(f"outputs/{output_name}/sample")
-    try:
-        for filename in os.listdir(samples_dir):
-            # Filename Schema: [name]_[steps]_[index]_[timestamp].png
-            match = re.search(r"_(\d+)_(\d+)_(\d+)\.png$", filename)
-            if match:
-                steps, index, timestamp = int(match.group(1)), int(match.group(2)), int(match.group(3))
-                sample_image_paths.append((steps, index, f"sample/{filename}"))
-
-        # Sort by numeric index
-        sample_image_paths.sort(key=lambda x: x[0], reverse=True)
-
-        final_sample_image_paths = sample_image_paths[:len(sample_prompts)]
-        final_sample_image_paths.sort(key=lambda x: x[1])
-        for i, prompt in enumerate(sample_prompts):
-            _, _, image_path = final_sample_image_paths[i]
-            widgets.append(
-                {
-                    "text": prompt,
-                    "output": {
-                        "url": image_path
-                    },
-                }
-            )
-    except:
-        print(f"no samples")
-    dtype = "torch.bfloat16"
-    # Construct the README content
-    readme_content = f"""---
-tags:
-{yaml.dump(tags, indent=4).strip()}
-{"widget:" if os.path.isdir(samples_dir) else ""}
-{yaml.dump(widgets, indent=4).strip() if widgets else ""}
-base_model: {base_model_name}
-{"instance_prompt: " + instance_prompt if instance_prompt else ""}
-{license_str}
----
-
-# {lora_name}
-
-A Flux LoRA trained on a local computer with [Fluxgym](https://github.com/cocktailpeanut/fluxgym)
-
-<Gallery />
-
-## Trigger words
-
-{"You should use `" + instance_prompt + "` to trigger the image generation." if instance_prompt else "No trigger words defined."}
-
-## Download model and use it with ComfyUI, AUTOMATIC1111, SD.Next, Invoke AI, Forge, etc.
-
-Weights for this model are available in Safetensors format.
-
-"""
-    return readme_content
 
 def account_hf():
     try:
@@ -216,57 +143,6 @@ def load_captioning(uploaded_files, concept_sentence):
 def hide_captioning():
     return gr.update(visible=False), gr.update(visible=False)
 
-def resize_image(image_path, output_path, size):
-    with Image.open(image_path) as img:
-        width, height = img.size
-        if width < height:
-            new_width = size
-            new_height = int((size/width) * height)
-        else:
-            new_height = size
-            new_width = int((size/height) * width)
-        print(f"resize {image_path} : {new_width}x{new_height}")
-        img_resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-        img_resized.save(output_path)
-
-def create_dataset(destination_folder, size, *inputs):
-    print("Creating dataset")
-    images = inputs[0]
-    if not os.path.exists(destination_folder):
-        os.makedirs(destination_folder)
-
-    for index, image in enumerate(images):
-        # copy the images to the datasets folder
-        new_image_path = shutil.copy(image, destination_folder)
-
-        # if it's a caption text file skip the next bit
-        ext = os.path.splitext(new_image_path)[-1].lower()
-        if ext == '.txt':
-            continue
-
-        # resize the images
-        resize_image(new_image_path, new_image_path, size)
-
-        # copy the captions
-
-        original_caption = inputs[index + 1]
-
-        image_file_name = os.path.basename(new_image_path)
-        caption_file_name = os.path.splitext(image_file_name)[0] + ".txt"
-        caption_path = resolve_path_without_quotes(os.path.join(destination_folder, caption_file_name))
-        print(f"image_path={new_image_path}, caption_path = {caption_path}, original_caption={original_caption}")
-        # if caption_path exists, do not write
-        if os.path.exists(caption_path):
-            print(f"{caption_path} already exists. use the existing .txt file")
-        else:
-            print(f"{caption_path} create a .txt caption file")
-            with open(caption_path, 'w') as file:
-                file.write(original_caption)
-
-    print(f"destination_folder {destination_folder}")
-    return destination_folder
-
-
 def run_captioning(images, concept_sentence, *captions):
     print(f"run_captioning")
     print(f"concept sentence {concept_sentence}")
@@ -321,58 +197,6 @@ def recursive_update(d, u):
         else:
             d[k] = v
     return d
-
-def download(base_model):
-    model = models[base_model]
-    model_file = model["file"]
-    repo = model["repo"]
-
-    # download unet
-    if base_model == "flux-dev" or base_model == "flux-schnell":
-        unet_folder = "models/unet"
-    else:
-        unet_folder = f"models/unet/{repo}"
-    unet_path = os.path.join(unet_folder, model_file)
-    if not os.path.exists(unet_path):
-        os.makedirs(unet_folder, exist_ok=True)
-        gr.Info(f"Downloading base model: {base_model}. Please wait. (You can check the terminal for the download progress)", duration=None)
-        print(f"download {base_model}")
-        hf_hub_download(repo_id=repo, local_dir=unet_folder, filename=model_file)
-
-    # download vae
-    vae_folder = "models/vae"
-    vae_path = os.path.join(vae_folder, "ae.sft")
-    if not os.path.exists(vae_path):
-        os.makedirs(vae_folder, exist_ok=True)
-        gr.Info(f"Downloading vae")
-        print(f"downloading ae.sft...")
-        hf_hub_download(repo_id="cocktailpeanut/xulf-dev", local_dir=vae_folder, filename="ae.sft")
-
-    # download clip
-    clip_folder = "models/clip"
-    clip_l_path = os.path.join(clip_folder, "clip_l.safetensors")
-    if not os.path.exists(clip_l_path):
-        os.makedirs(clip_folder, exist_ok=True)
-        gr.Info(f"Downloading clip...")
-        print(f"download clip_l.safetensors")
-        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="clip_l.safetensors")
-
-    # download t5xxl
-    t5xxl_path = os.path.join(clip_folder, "t5xxl_fp16.safetensors")
-    if not os.path.exists(t5xxl_path):
-        print(f"download t5xxl_fp16.safetensors")
-        gr.Info(f"Downloading t5xxl...")
-        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="t5xxl_fp16.safetensors")
-
-
-def resolve_path(p):
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    norm_path = os.path.normpath(os.path.join(current_dir, p))
-    return f"\"{norm_path}\""
-def resolve_path_without_quotes(p):
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    norm_path = os.path.normpath(os.path.join(current_dir, p))
-    return norm_path
 
 def gen_sh(
     base_model,
@@ -583,7 +407,28 @@ def start_training(
     if not os.path.exists(output_dir):
         os.makedirs(output_dir, exist_ok=True)
 
-    download(base_model)
+    # If RunPod is configured (.env), run training on a remote GPU instead of
+    # locally. The dataset has already been created locally by create_dataset.
+    if runpod_client.is_remote_enabled():
+        runner = LogsViewRunner()
+        dataset_dir = resolve_path_without_quotes(f"datasets/{output_name}")
+        local_root = os.path.dirname(os.path.abspath(__file__))
+        gr.Info("Submitting training job to RunPod...", duration=None)
+        yield runner.log(f"[RunPod] Submitting '{lora_name}' to serverless endpoint {os.environ.get('RUNPOD_ENDPOINT_ID')}")
+        for line in runpod_client.submit_training(
+            base_model=base_model,
+            lora_name=lora_name,
+            train_script=train_script,
+            train_config=train_config,
+            sample_prompts=sample_prompts,
+            dataset_dir=dataset_dir,
+            local_root=local_root,
+        ):
+            yield runner.log(line)
+        gr.Info("Remote training finished. Check the terminal log for the HuggingFace URL.", duration=None)
+        return
+
+    download(base_model, info=lambda m: gr.Info(m, duration=None))
 
     file_type = "sh"
     if sys.platform == "win32":

--- a/fluxgym_core.py
+++ b/fluxgym_core.py
@@ -1,0 +1,217 @@
+"""
+UI-free core helpers shared between the Gradio app (app.py) and the RunPod
+serverless worker (runpod/handler.py).
+
+app.py builds the entire Gradio Blocks at import time, so the serverless handler
+cannot import it. Everything here is pure logic (model registry, path helpers,
+model download, dataset creation, README generation) with no Gradio dependency,
+so both entrypoints can import it safely.
+"""
+import os
+import re
+import shutil
+import yaml
+from PIL import Image
+from slugify import slugify
+from huggingface_hub import hf_hub_download
+
+# Load the model registry relative to this file (robust regardless of cwd).
+_CORE_DIR = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(_CORE_DIR, "models.yaml"), "r") as _f:
+    models = yaml.safe_load(_f)
+
+
+def resolve_path(p):
+    """Absolute, shell-quoted path under the repo root (for train.sh)."""
+    norm_path = os.path.normpath(os.path.join(_CORE_DIR, p))
+    return f"\"{norm_path}\""
+
+
+def resolve_path_without_quotes(p):
+    """Absolute path under the repo root, no quoting (for filesystem ops)."""
+    return os.path.normpath(os.path.join(_CORE_DIR, p))
+
+
+def readme(base_model, lora_name, instance_prompt, sample_prompts):
+    # model license
+    model_config = models[base_model]
+    model_file = model_config["file"]
+    base_model_name = model_config["base"]
+    license = None
+    license_name = None
+    license_link = None
+    license_items = []
+    if "license" in model_config:
+        license = model_config["license"]
+        license_items.append(f"license: {license}")
+    if "license_name" in model_config:
+        license_name = model_config["license_name"]
+        license_items.append(f"license_name: {license_name}")
+    if "license_link" in model_config:
+        license_link = model_config["license_link"]
+        license_items.append(f"license_link: {license_link}")
+    license_str = "\n".join(license_items)
+    print(f"license_items={license_items}")
+    print(f"license_str = {license_str}")
+
+    # tags
+    tags = ["text-to-image", "flux", "lora", "diffusers", "template:sd-lora", "fluxgym"]
+
+    # widgets
+    widgets = []
+    sample_image_paths = []
+    output_name = slugify(lora_name)
+    samples_dir = resolve_path_without_quotes(f"outputs/{output_name}/sample")
+    try:
+        for filename in os.listdir(samples_dir):
+            # Filename Schema: [name]_[steps]_[index]_[timestamp].png
+            match = re.search(r"_(\d+)_(\d+)_(\d+)\.png$", filename)
+            if match:
+                steps, index, timestamp = int(match.group(1)), int(match.group(2)), int(match.group(3))
+                sample_image_paths.append((steps, index, f"sample/{filename}"))
+
+        # Sort by numeric index
+        sample_image_paths.sort(key=lambda x: x[0], reverse=True)
+
+        final_sample_image_paths = sample_image_paths[:len(sample_prompts)]
+        final_sample_image_paths.sort(key=lambda x: x[1])
+        for i, prompt in enumerate(sample_prompts):
+            _, _, image_path = final_sample_image_paths[i]
+            widgets.append(
+                {
+                    "text": prompt,
+                    "output": {
+                        "url": image_path
+                    },
+                }
+            )
+    except:
+        print(f"no samples")
+    dtype = "torch.bfloat16"
+    # Construct the README content
+    readme_content = f"""---
+tags:
+{yaml.dump(tags, indent=4).strip()}
+{"widget:" if os.path.isdir(samples_dir) else ""}
+{yaml.dump(widgets, indent=4).strip() if widgets else ""}
+base_model: {base_model_name}
+{"instance_prompt: " + instance_prompt if instance_prompt else ""}
+{license_str}
+---
+
+# {lora_name}
+
+A Flux LoRA trained on a local computer with [Fluxgym](https://github.com/cocktailpeanut/fluxgym)
+
+<Gallery />
+
+## Trigger words
+
+{"You should use `" + instance_prompt + "` to trigger the image generation." if instance_prompt else "No trigger words defined."}
+
+## Download model and use it with ComfyUI, AUTOMATIC1111, SD.Next, Invoke AI, Forge, etc.
+
+Weights for this model are available in Safetensors format.
+
+"""
+    return readme_content
+
+
+def download(base_model, info=print):
+    """Download the base model UNet + shared VAE/CLIP/T5 if not already present.
+
+    `info` is a single-argument logging callback (defaults to print). app.py
+    passes gr.Info so downloads surface as UI toasts; the worker passes print.
+    """
+    model = models[base_model]
+    model_file = model["file"]
+    repo = model["repo"]
+
+    # download unet
+    if base_model == "flux-dev" or base_model == "flux-schnell":
+        unet_folder = "models/unet"
+    else:
+        unet_folder = f"models/unet/{repo}"
+    unet_path = os.path.join(unet_folder, model_file)
+    if not os.path.exists(unet_path):
+        os.makedirs(unet_folder, exist_ok=True)
+        info(f"Downloading base model: {base_model}. Please wait. (You can check the terminal for the download progress)")
+        print(f"download {base_model}")
+        hf_hub_download(repo_id=repo, local_dir=unet_folder, filename=model_file)
+
+    # download vae
+    vae_folder = "models/vae"
+    vae_path = os.path.join(vae_folder, "ae.sft")
+    if not os.path.exists(vae_path):
+        os.makedirs(vae_folder, exist_ok=True)
+        info(f"Downloading vae")
+        print(f"downloading ae.sft...")
+        hf_hub_download(repo_id="cocktailpeanut/xulf-dev", local_dir=vae_folder, filename="ae.sft")
+
+    # download clip
+    clip_folder = "models/clip"
+    clip_l_path = os.path.join(clip_folder, "clip_l.safetensors")
+    if not os.path.exists(clip_l_path):
+        os.makedirs(clip_folder, exist_ok=True)
+        info(f"Downloading clip...")
+        print(f"download clip_l.safetensors")
+        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="clip_l.safetensors")
+
+    # download t5xxl
+    t5xxl_path = os.path.join(clip_folder, "t5xxl_fp16.safetensors")
+    if not os.path.exists(t5xxl_path):
+        print(f"download t5xxl_fp16.safetensors")
+        info(f"Downloading t5xxl...")
+        hf_hub_download(repo_id="comfyanonymous/flux_text_encoders", local_dir=clip_folder, filename="t5xxl_fp16.safetensors")
+
+
+def resize_image(image_path, output_path, size):
+    with Image.open(image_path) as img:
+        width, height = img.size
+        if width < height:
+            new_width = size
+            new_height = int((size / width) * height)
+        else:
+            new_height = size
+            new_width = int((size / height) * width)
+        print(f"resize {image_path} : {new_width}x{new_height}")
+        img_resized = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
+        img_resized.save(output_path)
+
+
+def create_dataset(destination_folder, size, *inputs):
+    print("Creating dataset")
+    images = inputs[0]
+    if not os.path.exists(destination_folder):
+        os.makedirs(destination_folder)
+
+    for index, image in enumerate(images):
+        # copy the images to the datasets folder
+        new_image_path = shutil.copy(image, destination_folder)
+
+        # if it's a caption text file skip the next bit
+        ext = os.path.splitext(new_image_path)[-1].lower()
+        if ext == '.txt':
+            continue
+
+        # resize the images
+        resize_image(new_image_path, new_image_path, size)
+
+        # copy the captions
+
+        original_caption = inputs[index + 1]
+
+        image_file_name = os.path.basename(new_image_path)
+        caption_file_name = os.path.splitext(image_file_name)[0] + ".txt"
+        caption_path = resolve_path_without_quotes(os.path.join(destination_folder, caption_file_name))
+        print(f"image_path={new_image_path}, caption_path = {caption_path}, original_caption={original_caption}")
+        # if caption_path exists, do not write
+        if os.path.exists(caption_path):
+            print(f"{caption_path} already exists. use the existing .txt file")
+        else:
+            print(f"{caption_path} create a .txt caption file")
+            with open(caption_path, 'w') as file:
+                file.write(original_caption)
+
+    print(f"destination_folder {destination_folder}")
+    return destination_folder

--- a/models.yaml
+++ b/models.yaml
@@ -25,3 +25,14 @@ bdsqlsz/flux1-dev2pro-single:
     license_name: flux-1-dev-non-commercial-license
     license_link: https://huggingface.co/black-forest-labs/FLUX.1-dev/blob/main/LICENSE.md
     file: flux1-dev2pro.safetensors
+# FLUX.1 Krea [dev]. Use the full bf16 single-file checkpoint (NOT the ComfyUI
+# fp8_scaled file, which trains to noise - see kohya-ss/sd-scripts#2166).
+# Krea is guidance-distilled like flux-dev, so the default --guidance_scale 1.0
+# recipe applies unchanged.
+flux-krea-dev:
+    repo: InvokeAI/FLUX.1-Krea-dev
+    base: black-forest-labs/FLUX.1-Krea-dev
+    license: other
+    license_name: flux-1-dev-non-commercial-license
+    license_link: https://huggingface.co/black-forest-labs/FLUX.1-Krea-dev/blob/main/LICENSE.md
+    file: flux1-krea-dev.safetensors

--- a/requirements-runpod.txt
+++ b/requirements-runpod.txt
@@ -1,0 +1,2 @@
+# Extra deps for the RunPod serverless worker (on top of requirements.txt).
+runpod>=1.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ python-slugify
 imagesize
 pydantic==2.9.2
 starlette==0.50.0
+runpod>=1.6.0

--- a/runpod/build_and_push.sh
+++ b/runpod/build_and_push.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Build the FluxGym RunPod serverless image for linux/amd64 and push it to your
+# registry. RunPod pulls the image from there when starting workers.
+#
+# Usage:
+#   DOCKER_IMAGE=docker.io/<user>/fluxgym-runpod:latest ./runpod/build_and_push.sh
+# or set DOCKER_IMAGE in .env (this script will source it).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Load .env if present so DOCKER_IMAGE can live there.
+if [ -f .env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . ./.env
+    set +a
+fi
+
+: "${DOCKER_IMAGE:?Set DOCKER_IMAGE (e.g. docker.io/<user>/fluxgym-runpod:latest) in .env or the environment}"
+
+echo "Building ${DOCKER_IMAGE} for linux/amd64..."
+docker buildx build \
+    --platform linux/amd64 \
+    -f Dockerfile.runpod \
+    -t "${DOCKER_IMAGE}" \
+    --push \
+    .
+
+echo "Pushed ${DOCKER_IMAGE}"
+echo "Set DOCKER_IMAGE=${DOCKER_IMAGE} in .env, then run: python runpod/deploy.py"

--- a/runpod/deploy.py
+++ b/runpod/deploy.py
@@ -1,0 +1,121 @@
+"""
+Provision the FluxGym RunPod serverless backend from .env.
+
+Steps:
+  1. Ensure a network volume exists (caches base models across jobs).
+  2. Create a serverless template referencing your pushed Docker image.
+  3. Create a serverless endpoint from that template, attaching the volume.
+  4. Print the endpoint id to paste back into .env as RUNPOD_ENDPOINT_ID.
+
+Prereqs:
+  - Build & push the image first:  ./runpod/build_and_push.sh
+  - Fill in .env (copy from .env.example), at minimum RUNPOD_API_KEY + DOCKER_IMAGE.
+
+Run:  python runpod/deploy.py
+"""
+import os
+import sys
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), ".env"))
+except Exception:
+    pass
+
+import runpod
+
+
+def env(name, default=None, required=False):
+    val = os.environ.get(name, default)
+    if required and not val:
+        sys.exit(f"Missing required env var: {name} (set it in .env)")
+    return val
+
+
+def ensure_network_volume(name, size_gb, data_center_id):
+    """Return a network volume id, creating one if RUNPOD_NETWORK_VOLUME_ID unset."""
+    existing = os.environ.get("RUNPOD_NETWORK_VOLUME_ID")
+    if existing:
+        print(f"Using existing network volume: {existing}")
+        return existing
+
+    # Prefer the SDK if it exposes volume creation; otherwise fall back to GraphQL.
+    create_fn = getattr(runpod, "create_network_volume", None)
+    if callable(create_fn):
+        vol = create_fn(name=name, size=int(size_gb), data_center_id=data_center_id)
+        vol_id = vol["id"] if isinstance(vol, dict) else vol
+        print(f"Created network volume: {vol_id}")
+        return vol_id
+
+    # GraphQL fallback.
+    import requests
+    query = """
+    mutation {
+      saveNetworkVolume(input: {name: "%s", size: %d, dataCenterId: "%s"}) {
+        id
+      }
+    }
+    """ % (name, int(size_gb), data_center_id)
+    resp = requests.post(
+        f"https://api.runpod.io/graphql?api_key={runpod.api_key}",
+        json={"query": query},
+        timeout=60,
+    )
+    data = resp.json()
+    if "errors" in data:
+        sys.exit(f"Failed to create network volume via GraphQL: {data['errors']}\n"
+                 f"Create one in the RunPod dashboard and set RUNPOD_NETWORK_VOLUME_ID in .env.")
+    vol_id = data["data"]["saveNetworkVolume"]["id"]
+    print(f"Created network volume (GraphQL): {vol_id}")
+    return vol_id
+
+
+def main():
+    runpod.api_key = env("RUNPOD_API_KEY", required=True)
+    image = env("DOCKER_IMAGE", required=True)
+    name = env("RUNPOD_NAME", "fluxgym-krea")
+    data_center_id = env("RUNPOD_DATA_CENTER_ID", "US-OR-1")
+    volume_size = env("RUNPOD_VOLUME_GB", "100")
+    container_disk = int(env("RUNPOD_CONTAINER_DISK_GB", "30"))
+    gpu_ids = env("RUNPOD_GPU_IDS", "AMPERE_48")  # 48GB Ampere pool (A40/A6000)
+    workers_max = int(env("RUNPOD_WORKERS_MAX", "1"))
+    idle_timeout = int(env("RUNPOD_IDLE_TIMEOUT", "60"))
+
+    # 1. Network volume (mounted at /runpod-volume by RunPod).
+    volume_id = ensure_network_volume(f"{name}-vol", volume_size, data_center_id)
+
+    # 2. Serverless template.
+    hf_token = env("HF_TOKEN", "")
+    template = runpod.create_template(
+        name=f"{name}-template",
+        image_name=image,
+        container_disk_in_gb=container_disk,
+        is_serverless=True,
+        env={"HF_TOKEN": hf_token, "HF_HUB_ENABLE_HF_TRANSFER": "1"},
+    )
+    template_id = template["id"] if isinstance(template, dict) else template
+    print(f"Created template: {template_id}")
+
+    # 3. Serverless endpoint (attaches the volume, scales to zero when idle).
+    endpoint = runpod.create_endpoint(
+        name=f"{name}-endpoint",
+        template_id=template_id,
+        gpu_ids=gpu_ids,
+        network_volume_id=volume_id,
+        workers_min=0,
+        workers_max=workers_max,
+        idle_timeout=idle_timeout,
+    )
+    endpoint_id = endpoint["id"] if isinstance(endpoint, dict) else endpoint
+
+    print("\n=== Done ===")
+    print(f"Endpoint id: {endpoint_id}")
+    print("\nNext: add this to your .env so the local UI routes training here:")
+    print(f"  RUNPOD_ENDPOINT_ID={endpoint_id}")
+    print(f"  RUNPOD_NETWORK_VOLUME_ID={volume_id}")
+    print("\nNOTE: training runs can be long. In the RunPod dashboard, raise the")
+    print("endpoint's Execution Timeout to cover your longest run (e.g. several hours).")
+
+
+if __name__ == "__main__":
+    main()

--- a/runpod/entrypoint.sh
+++ b/runpod/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Point ./models at the RunPod network volume so base models (Krea bf16 ~23GB,
+# T5 ~9GB, CLIP, VAE) download once and persist across invocations. Falls back
+# to a local ./models dir if no volume is attached.
+set -e
+cd /app/fluxgym
+
+VOLUME_MODELS="/runpod-volume/models"
+if [ -d "/runpod-volume" ]; then
+    mkdir -p "${VOLUME_MODELS}"
+    # Replace ./models with a symlink to the volume (unless already linked).
+    if [ ! -L "models" ]; then
+        rm -rf models
+        ln -s "${VOLUME_MODELS}" models
+    fi
+    echo "[entrypoint] models -> ${VOLUME_MODELS}"
+else
+    mkdir -p models
+    echo "[entrypoint] No /runpod-volume found; using local ./models (not persistent)"
+fi
+
+exec python3 -u runpod/handler.py

--- a/runpod/handler.py
+++ b/runpod/handler.py
@@ -1,0 +1,156 @@
+"""
+RunPod serverless worker for FluxGym training.
+
+Receives a training job from the local FluxGym UI (via runpod_client.py),
+recreates the dataset + scripts on the worker, runs Kohya sd-scripts on the
+GPU while streaming logs back, and pushes the resulting LoRA to HuggingFace.
+
+This is a generator handler: each yielded {"log": "..."} chunk is streamed to
+the client through the endpoint's /stream interface.
+"""
+import os
+import sys
+import base64
+import io
+import zipfile
+import subprocess
+
+# Repo root is the parent of this runpod/ directory (e.g. /app/fluxgym).
+REPO_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(REPO_DIR)
+sys.path.insert(0, REPO_DIR)
+sys.path.append(os.path.join(REPO_DIR, "sd-scripts"))
+
+os.environ.setdefault("HF_HUB_ENABLE_HF_TRANSFER", "1")
+
+import runpod
+from slugify import slugify
+from argparse import Namespace
+
+from fluxgym_core import models, download, readme, resolve_path_without_quotes
+from library import huggingface_util
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def _extract_dataset(dataset_zip_b64, dataset_dir):
+    os.makedirs(dataset_dir, exist_ok=True)
+    raw = base64.b64decode(dataset_zip_b64)
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        zf.extractall(dataset_dir)
+
+
+def handler(job):
+    inp = job.get("input", {}) or {}
+
+    base_model = inp.get("base_model")
+    lora_name = inp.get("lora_name")
+    train_script = inp.get("train_script")
+    train_config = inp.get("train_config")
+    sample_prompts = inp.get("sample_prompts", "")
+    local_root = inp.get("local_root")
+    dataset_zip_b64 = inp.get("dataset_zip_b64")
+
+    missing = [k for k in ("base_model", "lora_name", "train_script", "train_config",
+                           "local_root", "dataset_zip_b64") if not inp.get(k)]
+    if missing:
+        yield {"error": f"Missing required input fields: {missing}"}
+        return
+    if base_model not in models:
+        yield {"error": f"Unknown base_model '{base_model}'. Known: {list(models.keys())}"}
+        return
+
+    output_name = slugify(lora_name)
+
+    # 1. Rewrite the client's absolute repo-root paths to the worker's root.
+    #    train.sh / dataset.toml only contain host-specific paths under the repo
+    #    root (model/clip/t5/ae/dataset_config/output_dir/image_dir).
+    train_script = train_script.replace(local_root, REPO_DIR)
+    train_config = train_config.replace(local_root, REPO_DIR)
+
+    yield {"log": f"[worker] Rewrote paths {local_root} -> {REPO_DIR}"}
+
+    # 2. Recreate the dataset under datasets/<slug> (matches dataset.toml image_dir).
+    dataset_dir = resolve_path_without_quotes(f"datasets/{output_name}")
+    _extract_dataset(dataset_zip_b64, dataset_dir)
+    n_files = len(os.listdir(dataset_dir))
+    yield {"log": f"[worker] Dataset extracted to {dataset_dir} ({n_files} files)"}
+
+    # 3. Write the training scripts (same layout as the local start_training).
+    output_dir = resolve_path_without_quotes(f"outputs/{output_name}")
+    os.makedirs(output_dir, exist_ok=True)
+    sh_path = os.path.join(output_dir, "train.sh")
+    _write(sh_path, train_script)
+    _write(os.path.join(output_dir, "dataset.toml"), train_config)
+    _write(os.path.join(output_dir, "sample_prompts.txt"), sample_prompts)
+    yield {"log": f"[worker] Wrote train.sh / dataset.toml / sample_prompts.txt"}
+
+    # 4. Download base model + shared encoders (cached on the network volume).
+    yield {"log": f"[worker] Ensuring models for '{base_model}' (cached on volume)..."}
+    download(base_model)
+    yield {"log": "[worker] Models ready."}
+
+    # 5. Run training, streaming stdout line by line.
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["LOG_LEVEL"] = "DEBUG"
+    yield {"log": "[worker] Starting training..."}
+    proc = subprocess.Popen(
+        ["bash", sh_path],
+        cwd=REPO_DIR,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    for line in iter(proc.stdout.readline, ""):
+        yield {"log": line.rstrip("\n")}
+    proc.stdout.close()
+    rc = proc.wait()
+    yield {"log": f"[worker] Training process exited with code {rc}"}
+    if rc != 0:
+        yield {"error": f"Training failed (exit code {rc})"}
+        return
+
+    # 6. Generate README and push the LoRA folder to HuggingFace (if configured).
+    prompts = [p.strip() for p in sample_prompts.splitlines()
+               if p.strip() and not p.strip().startswith("#")]
+    config_class_tokens = None
+    try:
+        import toml as _toml
+        config_class_tokens = _toml.loads(train_config)["datasets"][0]["subsets"][0]["class_tokens"]
+    except Exception:
+        pass
+    md = readme(base_model, lora_name, config_class_tokens, prompts)
+    _write(os.path.join(output_dir, "README.md"), md)
+
+    hf_repo = inp.get("hf_repo")
+    hf_token = inp.get("hf_token") or os.environ.get("HF_TOKEN", "")
+    if hf_repo and hf_token:
+        yield {"log": f"[worker] Uploading LoRA to https://huggingface.co/{hf_repo} ..."}
+        args = Namespace(
+            huggingface_repo_id=hf_repo,
+            huggingface_repo_type="model",
+            huggingface_repo_visibility=inp.get("hf_visibility", "public"),
+            huggingface_path_in_repo="",
+            huggingface_token=hf_token,
+            async_upload=False,
+        )
+        try:
+            huggingface_util.upload(args=args, src=output_dir)
+            yield {"log": f"[worker] Upload complete: https://huggingface.co/{hf_repo}"}
+        except Exception as e:
+            yield {"log": f"[worker] HF upload failed: {e}. LoRA remains on the volume at {output_dir}"}
+    else:
+        yield {"log": f"[worker] No HF repo/token provided. LoRA saved on volume at {output_dir}"}
+
+    yield {"log": "[worker] Done."}
+
+
+if __name__ == "__main__":
+    runpod.serverless.start({"handler": handler, "return_aggregate_stream": True})

--- a/runpod_client.py
+++ b/runpod_client.py
@@ -1,0 +1,120 @@
+"""
+Local-side client that submits training jobs to a RunPod serverless endpoint
+and streams the worker's logs back into the FluxGym terminal.
+
+app.py routes training here (instead of running `bash train.sh` locally) when
+both RUNPOD_API_KEY and RUNPOD_ENDPOINT_ID are present in the environment
+(loaded from .env). Otherwise the local workflow is untouched.
+"""
+import os
+import io
+import base64
+import time
+import zipfile
+
+
+def is_remote_enabled():
+    """True when RunPod credentials + endpoint are configured in the env."""
+    return bool(os.environ.get("RUNPOD_API_KEY") and os.environ.get("RUNPOD_ENDPOINT_ID"))
+
+
+def _zip_dataset_b64(dataset_dir):
+    """Zip the (already resized) dataset folder and base64-encode it.
+
+    Files are stored relative to dataset_dir so the worker can recreate
+    datasets/<slug>/<files> verbatim.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for root, _, files in os.walk(dataset_dir):
+            for name in files:
+                full = os.path.join(root, name)
+                arc = os.path.relpath(full, dataset_dir)
+                zf.write(full, arc)
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def _resolve_hf_repo(lora_name):
+    """Build owner/<slug> from HF_REPO_OWNER, or "" to skip the HF push."""
+    owner = os.environ.get("HF_REPO_OWNER", "")
+    if not owner:
+        return ""
+    from slugify import slugify
+    return f"{owner}/{slugify(lora_name)}"
+
+
+def submit_training(base_model, lora_name, train_script, train_config,
+                    sample_prompts, dataset_dir, local_root):
+    """Submit a training job and yield log lines (strings) as they arrive."""
+    import runpod
+
+    runpod.api_key = os.environ["RUNPOD_API_KEY"]
+    endpoint = runpod.Endpoint(os.environ["RUNPOD_ENDPOINT_ID"])
+
+    dataset_b64 = _zip_dataset_b64(dataset_dir)
+    hf_repo = _resolve_hf_repo(lora_name)
+    payload = {
+        "base_model": base_model,
+        "lora_name": lora_name,
+        "train_script": train_script,
+        "train_config": train_config,
+        "sample_prompts": sample_prompts,
+        "local_root": local_root,
+        "dataset_zip_b64": dataset_b64,
+        "hf_token": os.environ.get("HF_TOKEN", ""),
+        "hf_repo": hf_repo,
+        "hf_visibility": os.environ.get("HF_VISIBILITY", "public"),
+    }
+
+    size_kb = len(dataset_b64) // 1024
+    yield f"[RunPod] Dataset packaged ({size_kb} KB). " + (
+        f"LoRA will be pushed to https://huggingface.co/{hf_repo}" if hf_repo
+        else "No HF_REPO_OWNER set - LoRA will stay on the network volume only."
+    )
+    if size_kb > 9000:
+        yield ("[RunPod] WARNING: encoded dataset is large (>~9MB) and may exceed the "
+               "endpoint request limit. Reduce image count/resolution, or stage the "
+               "dataset on the network volume / S3 if the job is rejected.")
+
+    job = endpoint.run(payload)
+    yield f"[RunPod] Job submitted: id={getattr(job, 'job_id', '?')}"
+
+    # Preferred path: stream incremental output from the generator handler.
+    try:
+        for output in job.stream():
+            for line in _extract_lines(output):
+                yield line
+        yield "[RunPod] Job complete."
+        return
+    except Exception as e:
+        yield f"[RunPod] Streaming unavailable ({e}); falling back to polling."
+
+    # Fallback: poll status, then dump final output.
+    terminal = ("COMPLETED", "FAILED", "CANCELLED", "TIMED_OUT")
+    while True:
+        status = job.status()
+        yield f"[RunPod] status={status}"
+        if status in terminal:
+            break
+        time.sleep(5)
+    for line in _extract_lines(job.output()):
+        yield line
+    yield "[RunPod] Job complete."
+
+
+def _extract_lines(output):
+    """Normalize a handler output chunk into a list of log line strings."""
+    lines = []
+    if output is None:
+        return lines
+    if isinstance(output, dict):
+        msg = output.get("log")
+        if msg is None:
+            msg = output.get("error") or str(output)
+        lines.append(str(msg).rstrip("\n"))
+    elif isinstance(output, list):
+        for item in output:
+            lines.extend(_extract_lines(item))
+    else:
+        lines.append(str(output).rstrip("\n"))
+    return lines


### PR DESCRIPTION
Adds FLUX.1 Krea [dev] as a trainable base model and a local-UI/remote-GPU training path so FluxGym can run on a CPU-only machine while training executes on a RunPod serverless GPU.

FLUX.1 Krea:
- New flux-krea-dev entry in models.yaml using the bf16 single-file checkpoint (InvokeAI/FLUX.1-Krea-dev). Deliberately not the ComfyUI fp8_scaled file, which trains to noise (kohya-ss/sd-scripts#2166). Krea is guidance-distilled like flux-dev, so the existing --guidance_scale 1.0 recipe applies unchanged; download()/gen_sh() already handle custom models generically, so no code change was needed for the model itself.

RunPod serverless training (opt-in via .env):
- fluxgym_core.py: extracted UI-free helpers (models, download, readme, create_dataset, path utils) so the worker can reuse them without importing the Gradio app; app.py now imports from it.
- runpod/handler.py: generator handler that rewrites the client's repo-root paths, recreates the dataset, caches base models on a network volume, runs Kohya sd-scripts while streaming logs, and pushes the LoRA to HuggingFace.
- runpod_client.py + start_training branch in app.py: when RUNPOD_API_KEY and RUNPOD_ENDPOINT_ID are set, the UI zips the dataset, submits the job, and streams remote logs into the existing terminal. Local behavior is unchanged when they are absent.
- Dockerfile.runpod + runpod/entrypoint.sh: serverless image that KEEPS sd-scripts (the stock Dockerfile deletes it) and symlinks models/ to the network volume.
- runpod/deploy.py: provisions volume + template + endpoint via the runpod SDK.
- runpod/build_and_push.sh, .env.example, .gitignore, requirements-runpod.txt, and runpod in requirements.txt.