### PR TITLE
pin diffusers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 safetensors
-git+https://github.com/huggingface/diffusers.git
+diffusers==0.38.0
 gradio_logsview@https://huggingface.co/spaces/cocktailpeanut/gradio_logsview/resolve/main/gradio_logsview-0.0.17-py3-none-any.whl
 transformers==4.49.0
 lycoris-lora==1.8.3


### PR DESCRIPTION
The new diffusers version requires a higher huggingface_hub version that is no longer compatible with the installed transformers version which breaks the installation of the requirements.

diffusers==0.40.0.dev0 depends on huggingface_hub>=1.23.0,<2.0
transformers==4.49.0 depends on huggingface-hub>=0.26.0,<1.0